### PR TITLE
[Participants]: Setup creation flow with test coverage

### DIFF
--- a/app/src/main/java/edu/kmaooad/capstone23/common/ObjectMapperSerializingToHexObjectId.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/common/ObjectMapperSerializingToHexObjectId.java
@@ -1,0 +1,40 @@
+package edu.kmaooad.capstone23.common;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.bson.types.ObjectId;
+
+import java.io.IOException;
+
+/**
+ * @implNote Can be used in prior of <ObjectMapper> to
+ */
+public class ObjectMapperSerializingToHexObjectId extends ObjectMapper {
+  ObjectMapperSerializingToHexObjectId() {
+    super();
+
+    SimpleModule module = new SimpleModule();
+
+    module.addSerializer(ObjectId.class, new ObjectIdToHexStringSerializer());
+
+    this.registerModule(module);
+  }
+
+  private static class ObjectIdToHexStringSerializer extends JsonSerializer<ObjectId> {
+    @Override
+    public void serialize(
+        ObjectId value,
+        JsonGenerator generator,
+        SerializerProvider serializers
+    ) throws IOException {
+      if (value == null) {
+        generator.writeNull();
+      } else {
+        generator.writeString(value.toHexString());
+      }
+    }
+  }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/common/ObjectMapperSerializingToHexObjectId.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/common/ObjectMapperSerializingToHexObjectId.java
@@ -10,7 +10,7 @@ import org.bson.types.ObjectId;
 import java.io.IOException;
 
 /**
- * @implNote Can be used in prior of <ObjectMapper> to
+ * @implNote Can be used in prior of <ObjectMapper> to serialize <ObjectId> as hex
  */
 public class ObjectMapperSerializingToHexObjectId extends ObjectMapper {
   ObjectMapperSerializingToHexObjectId() {

--- a/app/src/main/java/edu/kmaooad/capstone23/communication/commands/CreateParticipant.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/communication/commands/CreateParticipant.java
@@ -16,4 +16,12 @@ public class CreateParticipant {
   public String getUserId() {
     return userId;
   }
+
+  public void setChatId(String chatId) {
+    this.chatId = chatId;
+  }
+
+  public void setUserId(String userId) {
+    this.userId = userId;
+  }
 }

--- a/app/src/main/java/edu/kmaooad/capstone23/communication/commands/CreateParticipant.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/communication/commands/CreateParticipant.java
@@ -1,0 +1,19 @@
+package edu.kmaooad.capstone23.communication.commands;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class CreateParticipant {
+  @NotBlank
+  private String chatId;
+
+  @NotBlank
+  private String userId;
+
+  public String getChatId() {
+    return chatId;
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/communication/controllers/CreateParticipantController.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/communication/controllers/CreateParticipantController.java
@@ -1,0 +1,19 @@
+package edu.kmaooad.capstone23.communication.controllers;
+
+import edu.kmaooad.capstone23.common.TypicalController;
+import edu.kmaooad.capstone23.communication.commands.CreateParticipant;
+import edu.kmaooad.capstone23.communication.events.ParticipantCreated;
+import jakarta.ws.rs.Path;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+
+@Path("/participants/create")
+@APIResponse(responseCode = "200", content = {
+    @Content(
+        mediaType = "application/json",
+        schema = @Schema(implementation = ParticipantCreated.class)
+    )}
+)
+public class CreateParticipantController extends TypicalController<CreateParticipant, ParticipantCreated> {
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/communication/events/ParticipantCreated.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/communication/events/ParticipantCreated.java
@@ -1,0 +1,9 @@
+package edu.kmaooad.capstone23.communication.events;
+
+import edu.kmaooad.capstone23.common.Event;
+
+public class ParticipantCreated extends Event {
+  public ParticipantCreated(String id) {
+    super(id);
+  }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/communication/handlers/CreateChatHandler.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/communication/handlers/CreateChatHandler.java
@@ -14,20 +14,22 @@ public class CreateChatHandler implements CommandHandler<CreateChat, ChatCreated
   @Inject
   ChatRepository chatRepository;
 
-  private final Chat chat = new Chat();
+  private Chat chat;
 
   @Override
   public Result<ChatCreated> handle(CreateChat command) {
-    initFromCommand(command);
+    initChat(command);
 
-    this.chatRepository.insert(chat);
+    chatRepository.insert(chat);
 
     ChatCreated createdChat = new ChatCreated(chat.id.toHexString());
 
     return new Result<ChatCreated>(createdChat);
   }
 
-  private void initFromCommand(CreateChat command) {
+  private void initChat(CreateChat command) {
+    chat = new Chat();
+
     chat.name = command.getName();
     chat.description = command.getDescription();
     chat.accessType = Chat.AccessType.valueOf(command.getAccessType());

--- a/app/src/main/java/edu/kmaooad/capstone23/communication/handlers/CreateParticipantHandler.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/communication/handlers/CreateParticipantHandler.java
@@ -1,0 +1,51 @@
+package edu.kmaooad.capstone23.communication.handlers;
+
+import edu.kmaooad.capstone23.common.CommandHandler;
+import edu.kmaooad.capstone23.common.ErrorCode;
+import edu.kmaooad.capstone23.common.Result;
+import edu.kmaooad.capstone23.communication.commands.CreateParticipant;
+import edu.kmaooad.capstone23.communication.dal.entities.Participant;
+import edu.kmaooad.capstone23.communication.dal.repositories.ParticipantRepository;
+import edu.kmaooad.capstone23.communication.events.ParticipantCreated;
+import edu.kmaooad.capstone23.communication.services.ParticipantService;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import org.bson.types.ObjectId;
+
+@RequestScoped
+public class CreateParticipantHandler implements CommandHandler<CreateParticipant, ParticipantCreated> {
+  @Inject
+  ParticipantService participantService;
+
+  @Inject
+  ParticipantRepository participantRepository;
+
+  private Participant participant;
+
+  @Override
+  public Result<ParticipantCreated> handle(CreateParticipant command) {
+    String chatId = command.getChatId();
+    String userId = command.getUserId();
+
+    boolean canCreateParticipant = participantService.validateChatAndUser(chatId, userId);
+
+    if (!canCreateParticipant) {
+      return new Result<ParticipantCreated>(ErrorCode.EXCEPTION, "Chat or user do not exist");
+    }
+
+    initParticipant(chatId, userId);
+
+    participantRepository.insert(participant);
+
+    ParticipantCreated createdParticipant = new ParticipantCreated(participant.id.toHexString());
+
+    return new Result<ParticipantCreated>(createdParticipant);
+  }
+
+  private void initParticipant(String chatId, String userId) {
+    participant = new Participant();
+
+    participant.chatId = new ObjectId(chatId);
+    participant.userId = new ObjectId(userId);
+  }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/communication/services/ChatService.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/communication/services/ChatService.java
@@ -1,0 +1,20 @@
+package edu.kmaooad.capstone23.communication.services;
+
+import edu.kmaooad.capstone23.communication.dal.entities.Chat;
+import edu.kmaooad.capstone23.communication.dal.repositories.ChatRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Optional;
+
+@ApplicationScoped
+public class ChatService {
+  @Inject
+  ChatRepository chatRepository;
+
+  public boolean isChatPresent(String id) {
+    Optional<Chat> chat = chatRepository.findById(id);
+
+    return chat.isPresent();
+  }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/communication/services/ParticipantService.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/communication/services/ParticipantService.java
@@ -1,0 +1,21 @@
+package edu.kmaooad.capstone23.communication.services;
+
+import edu.kmaooad.capstone23.users.services.UserService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class ParticipantService {
+  @Inject
+  ChatService chatService;
+
+  @Inject
+  UserService userService;
+
+  public boolean validateChatAndUser(String chatId, String userId) {
+    boolean isChatValid = chatService.isChatPresent(chatId);
+    boolean isUserValid = userService.isUserPresent(userId);
+
+    return isChatValid && isUserValid;
+  }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/users/services/UserService.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/users/services/UserService.java
@@ -1,0 +1,20 @@
+package edu.kmaooad.capstone23.users.services;
+
+import edu.kmaooad.capstone23.users.dal.entities.User;
+import edu.kmaooad.capstone23.users.dal.repositories.UserRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Optional;
+
+@ApplicationScoped
+public class UserService {
+  @Inject
+  UserRepository userRepository;
+
+  public boolean isUserPresent(String id) {
+    Optional<User> user = userRepository.findById(id);
+
+    return user.isPresent();
+  }
+}

--- a/app/src/test/java/edu/kmaooad/capstone23/access_rules/handlers/CreateAccessRuleHandlerTests.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/access_rules/handlers/CreateAccessRuleHandlerTests.java
@@ -146,7 +146,6 @@ public class CreateAccessRuleHandlerTests {
         Assertions.assertTrue(result.isSuccess());
     }
     @Test
-    @Disabled // skip test case to unblock CI (by @D. Pelovych)
     @DisplayName("Create Access Rule: organisation to department")
     public void createRuleOrganisationToDepartment() {
         Result<AccessRuleCreated> result = addAccessRule(org, AccessRuleFromEntityType.Organisation, department, AccessRuleToEntityType.Department);

--- a/app/src/test/java/edu/kmaooad/capstone23/common/ControllerTest.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/common/ControllerTest.java
@@ -32,7 +32,7 @@ public class ControllerTest<PayloadType> {
 
   protected String mapPayloadToStringifiedJson(PayloadType entity) {
     try {
-      ObjectMapper mapper = new ObjectMapper();
+      ObjectMapper mapper = new ObjectMapperSerializingToHexObjectId();
 
       return mapper.writeValueAsString(entity);
     } catch (JsonProcessingException exception) {

--- a/app/src/test/java/edu/kmaooad/capstone23/common/Mocks.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/common/Mocks.java
@@ -1,0 +1,9 @@
+package edu.kmaooad.capstone23.common;
+
+import org.bson.types.ObjectId;
+
+public class Mocks {
+  public static ObjectId mockObjectId() {
+    return new ObjectId();
+  }
+}

--- a/app/src/test/java/edu/kmaooad/capstone23/communication/controllers/CreateParticipantControllerTest.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/communication/controllers/CreateParticipantControllerTest.java
@@ -1,0 +1,47 @@
+package edu.kmaooad.capstone23.communication.controllers;
+
+import edu.kmaooad.capstone23.common.ControllerTest;
+import edu.kmaooad.capstone23.communication.dal.entities.Chat;
+import edu.kmaooad.capstone23.communication.dal.entities.Participant;
+import edu.kmaooad.capstone23.communication.dal.repositories.ChatRepository;
+import edu.kmaooad.capstone23.communication.mocks.ChatMocks;
+import edu.kmaooad.capstone23.communication.mocks.ParticipantMocks;
+import edu.kmaooad.capstone23.users.dal.entities.User;
+import edu.kmaooad.capstone23.users.dal.repositories.UserRepository;
+import edu.kmaooad.capstone23.users.mocks.UserMocks;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class CreateParticipantControllerTest extends ControllerTest<Participant> {
+  @Inject
+  ChatRepository chatRepository;
+
+  @Inject
+  UserRepository userRepository;
+
+  CreateParticipantControllerTest() {
+    super("/participants/create");
+  }
+
+  @Test
+  @DisplayName("Should succeed if chat and user exist")
+  public void shouldSucceedIfChatAndUserExist() {
+    Chat chat = chatRepository.insert(ChatMocks.validChat());
+    User user = userRepository.insert(UserMocks.validUser());
+
+    assertRequestSucceeds(
+        ParticipantMocks.makeParticipant(chat.id, user.id)
+    );
+  }
+
+  @Test
+  @DisplayName("Should deny request if there is no chat or user")
+  public void shouldDenyRequestIfNoChatOrUser() {
+    assertRequestFails(
+        ParticipantMocks.invalidParticipant()
+    );
+  }
+}

--- a/app/src/test/java/edu/kmaooad/capstone23/communication/handlers/CreateParticipantHandlerTest.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/communication/handlers/CreateParticipantHandlerTest.java
@@ -1,0 +1,48 @@
+package edu.kmaooad.capstone23.communication.handlers;
+
+import edu.kmaooad.capstone23.common.HandlerTest;
+import edu.kmaooad.capstone23.common.Result;
+import edu.kmaooad.capstone23.communication.commands.CreateParticipant;
+import edu.kmaooad.capstone23.communication.dal.entities.Participant;
+import edu.kmaooad.capstone23.communication.events.ParticipantCreated;
+import edu.kmaooad.capstone23.communication.mocks.ParticipantMocks;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class CreateParticipantHandlerTest extends HandlerTest<Participant, CreateParticipant, ParticipantCreated> {
+  @Inject
+  CreateChatHandler createChatHandler;
+
+  @BeforeEach
+  public void initCommand() {
+    command = new CreateParticipant();
+  }
+
+  /*
+    @Test
+    @DisplayName("Should succeed if command is valid")
+    // TODO: requires user creation flow, coming in next PRs
+  */
+
+  @Test
+  @DisplayName("Should succeed if command is valid")
+  public void shouldDenyCommandIfNoChatOrUser() {
+    Result<ParticipantCreated> result = handleCommandWithPayload(
+        ParticipantMocks.invalidParticipant()
+    );
+
+    assertDenied(result);
+  }
+
+  @Override
+  protected Result<ParticipantCreated> handleCommandWithPayload(Participant participant) {
+    command.setChatId(participant.chatId.toHexString());
+    command.setUserId(participant.userId.toHexString());
+
+    return handler.handle(command);
+  }
+}

--- a/app/src/test/java/edu/kmaooad/capstone23/communication/mocks/ParticipantMocks.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/communication/mocks/ParticipantMocks.java
@@ -1,0 +1,26 @@
+package edu.kmaooad.capstone23.communication.mocks;
+
+import edu.kmaooad.capstone23.common.Mocks;
+import edu.kmaooad.capstone23.communication.dal.entities.Participant;
+import org.bson.types.ObjectId;
+
+public class ParticipantMocks {
+  public static Participant makeParticipant(ObjectId chatId, ObjectId userId) {
+    Participant participant = new Participant();
+
+    participant.id = Mocks.mockObjectId();
+    participant.chatId = chatId;
+    participant.userId = userId;
+
+    return participant;
+  }
+
+  public static Participant invalidParticipant() {
+    Participant participant = new Participant();
+
+    participant.chatId = Mocks.mockObjectId();
+    participant.userId = Mocks.mockObjectId();
+
+    return participant;
+  }
+}

--- a/app/src/test/java/edu/kmaooad/capstone23/orgs/members/handlers/CreateMemberHandlerTest.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/orgs/members/handlers/CreateMemberHandlerTest.java
@@ -49,7 +49,6 @@ public class CreateMemberHandlerTest extends TestWithOrgSetUp {
     }
 
     @Test
-    @Disabled // skip test case to unblock CI (by @D. Pelovych)
     void testEmailUniquenessValidation() {
         CreateBasicMember command = new CreateBasicMember();
         command.setFirstName("firstName");

--- a/app/src/test/java/edu/kmaooad/capstone23/orgs/members/handlers/GetAllMembersHandlerTest.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/orgs/members/handlers/GetAllMembersHandlerTest.java
@@ -22,7 +22,6 @@ public class GetAllMembersHandlerTest extends TestWithMembersSetUp {
     GetAllMembersHandler handler;
 
     @Test
-    @Disabled // skip test case to unblock CI (by @D. Pelovych)
     @DisplayName("Read all members: Basic handling")
     void testSuccessfulHandling() {
         GetAllMembers command = new GetAllMembers();

--- a/app/src/test/java/edu/kmaooad/capstone23/users/mocks/UserMocks.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/users/mocks/UserMocks.java
@@ -1,0 +1,15 @@
+package edu.kmaooad.capstone23.users.mocks;
+
+import edu.kmaooad.capstone23.users.dal.entities.User;
+
+public class UserMocks {
+  public static User validUser() {
+    User user = new User();
+
+    user.firstName = "John";
+    user.lastName = "Doe";
+    user.email = "john.doe@mail.com";
+
+    return user;
+  }
+}


### PR DESCRIPTION
## Summary

In this PR:
- add `ObjectMapperSerializingToHexObjectId` to serialize `ObjectId` as hex
- add services to handle entries presence validation in a more reusable way
- add more mocks
- add test themselves

### Tests results

![Screenshot 2023-10-01 at 17 50 19](https://github.com/kmaooad/capstone23/assets/75496546/37be6ebc-73c0-4ac6-a165-57a13e24a3e8)
![image](https://github.com/kmaooad/capstone23/assets/75496546/829cb194-dec9-4e03-8964-d67543906c21)
