### PR TITLE
[Users]: Setup creation flow with test coverage

### DIFF
--- a/app/src/main/java/edu/kmaooad/capstone23/users/commands/CreateUser.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/users/commands/CreateUser.java
@@ -1,0 +1,43 @@
+package edu.kmaooad.capstone23.users.commands;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class CreateUser {
+  @NotBlank
+  @Size(min = 2, max = 50)
+  private String firstName;
+
+  @NotBlank
+  @Size(min = 2, max = 50)
+  private String lastName;
+
+  @NotBlank
+  @Email
+  private String email;
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public String getEmailName() {
+    return email;
+  }
+
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/users/controllers/CreateUserController.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/users/controllers/CreateUserController.java
@@ -1,0 +1,19 @@
+package edu.kmaooad.capstone23.users.controllers;
+
+import edu.kmaooad.capstone23.common.TypicalController;
+import edu.kmaooad.capstone23.users.commands.CreateUser;
+import edu.kmaooad.capstone23.users.events.UserCreated;
+import jakarta.ws.rs.Path;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+
+@Path("/users/create")
+@APIResponse(responseCode = "200", content = {
+    @Content(
+        mediaType = "application/json",
+        schema = @Schema(implementation = UserCreated.class)
+    )}
+)
+public class CreateUserController extends TypicalController<CreateUser, UserCreated> {
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/users/events/UserCreated.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/users/events/UserCreated.java
@@ -1,0 +1,9 @@
+package edu.kmaooad.capstone23.users.events;
+
+import edu.kmaooad.capstone23.common.Event;
+
+public class UserCreated extends Event {
+  public UserCreated(String id) {
+    super(id);
+  }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/users/handlers/CreateUserHandler.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/users/handlers/CreateUserHandler.java
@@ -1,0 +1,37 @@
+package edu.kmaooad.capstone23.users.handlers;
+
+import edu.kmaooad.capstone23.common.CommandHandler;
+import edu.kmaooad.capstone23.common.Result;
+import edu.kmaooad.capstone23.users.commands.CreateUser;
+import edu.kmaooad.capstone23.users.dal.entities.User;
+import edu.kmaooad.capstone23.users.dal.repositories.UserRepository;
+import edu.kmaooad.capstone23.users.events.UserCreated;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+
+@RequestScoped
+public class CreateUserHandler implements CommandHandler<CreateUser, UserCreated> {
+  @Inject
+  UserRepository userRepository;
+
+  private User user;
+
+  @Override
+  public Result<UserCreated> handle(CreateUser command) {
+    initUser(command);
+
+    userRepository.insert(user);
+
+    UserCreated createdUser = new UserCreated(user.id.toHexString());
+
+    return new Result<UserCreated>(createdUser);
+  }
+
+  private void initUser(CreateUser command) {
+    user = new User();
+
+    user.firstName = command.getFirstName();
+    user.lastName = command.getLastName();
+    user.email = command.getEmailName();
+  }
+}

--- a/app/src/test/java/edu/kmaooad/capstone23/common/HandlerTest.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/common/HandlerTest.java
@@ -9,7 +9,16 @@ public abstract class HandlerTest<EntityType, CommandType, EventType extends Eve
   @Inject
   protected CommandHandler<CommandType, EventType> handler;
 
-  protected abstract Result<EventType> handleCommandWithPayload(EntityType entity);
+  protected abstract void initCommand();
+
+  protected abstract void insertPayload(EntityType entity);
+
+  protected Result<EventType> run(EntityType entity) {
+    initCommand();
+    insertPayload(entity);
+
+    return handler.handle(command);
+  }
 
   protected void assertHandled(Result<EventType> result) {
     Assertions.assertTrue(result.isSuccess());

--- a/app/src/test/java/edu/kmaooad/capstone23/common/Mocks.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/common/Mocks.java
@@ -6,4 +6,16 @@ public class Mocks {
   public static ObjectId mockObjectId() {
     return new ObjectId();
   }
+
+  public static String mockLongString() {
+    return "Lorem".repeat(100);
+  }
+
+  public static String mockInvalidEmail() {
+    return "example@";
+  }
+
+  public static String mockValidEmail() {
+    return "john.doe@mail.com";
+  }
 }

--- a/app/src/test/java/edu/kmaooad/capstone23/communication/handlers/CreateChatHandlerTest.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/communication/handlers/CreateChatHandlerTest.java
@@ -7,28 +7,16 @@ import edu.kmaooad.capstone23.communication.dal.entities.Chat;
 import edu.kmaooad.capstone23.communication.events.ChatCreated;
 import edu.kmaooad.capstone23.communication.mocks.ChatMocks;
 import io.quarkus.test.junit.QuarkusTest;
-import jakarta.inject.Inject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 
 @QuarkusTest
 public class CreateChatHandlerTest extends HandlerTest<Chat, CreateChat, ChatCreated> {
-  private CreateChat command;
-
-  @Inject
-  CreateChatHandler handler;
-
-  @BeforeEach
-  public void initCommand() {
-    command = new CreateChat();
-  }
-
   @Test
   @DisplayName("Should succeed if command is valid")
-  public void shouldSucceedIfCommandValid() {
-    Result<ChatCreated> result = handleCommandWithPayload(ChatMocks.validChat());
+  public void shouldSucceedIfValidCommand() {
+    Result<ChatCreated> result = run(ChatMocks.validChat());
 
     assertHandled(result);
   }
@@ -36,7 +24,7 @@ public class CreateChatHandlerTest extends HandlerTest<Chat, CreateChat, ChatCre
   @Test
   @DisplayName("Should deny command if chat access type is invalid")
   public void shouldDenyCommandIfInvalidAccessType() {
-    Result<ChatCreated> result = handleCommandWithPayload(ChatMocks.chatWithNoType());
+    Result<ChatCreated> result = run(ChatMocks.chatWithNoType());
 
     assertDenied(result);
   }
@@ -44,7 +32,7 @@ public class CreateChatHandlerTest extends HandlerTest<Chat, CreateChat, ChatCre
   @Test
   @DisplayName("Should deny command if chat name is exhaustive")
   public void shouldDenyCommandIfExhaustiveName() {
-    Result<ChatCreated> result = handleCommandWithPayload(ChatMocks.chatWithExhaustiveName());
+    Result<ChatCreated> result = run(ChatMocks.chatWithExhaustiveName());
 
     assertDenied(result);
   }
@@ -52,16 +40,19 @@ public class CreateChatHandlerTest extends HandlerTest<Chat, CreateChat, ChatCre
   @Test
   @DisplayName("Should deny command if chat name is empty")
   public void shouldDenyCommandIfEmptyName() {
-    Result<ChatCreated> result = handleCommandWithPayload(ChatMocks.chatWithNoName());
+    Result<ChatCreated> result = run(ChatMocks.chatWithNoName());
 
     assertDenied(result);
   }
 
   @Override
-  protected Result<ChatCreated> handleCommandWithPayload(Chat chat) {
+  public void initCommand() {
+    command = new CreateChat();
+  }
+
+  @Override
+  protected void insertPayload(Chat chat) {
     command.setName(chat.name);
     command.setAccessType(chat.accessType);
-
-    return handler.handle(command);
   }
 }

--- a/app/src/test/java/edu/kmaooad/capstone23/communication/handlers/CreateParticipantHandlerTest.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/communication/handlers/CreateParticipantHandlerTest.java
@@ -2,13 +2,22 @@ package edu.kmaooad.capstone23.communication.handlers;
 
 import edu.kmaooad.capstone23.common.HandlerTest;
 import edu.kmaooad.capstone23.common.Result;
+import edu.kmaooad.capstone23.communication.commands.CreateChat;
 import edu.kmaooad.capstone23.communication.commands.CreateParticipant;
+import edu.kmaooad.capstone23.communication.dal.entities.Chat;
 import edu.kmaooad.capstone23.communication.dal.entities.Participant;
+import edu.kmaooad.capstone23.communication.events.ChatCreated;
 import edu.kmaooad.capstone23.communication.events.ParticipantCreated;
+import edu.kmaooad.capstone23.communication.mocks.ChatMocks;
 import edu.kmaooad.capstone23.communication.mocks.ParticipantMocks;
+import edu.kmaooad.capstone23.users.commands.CreateUser;
+import edu.kmaooad.capstone23.users.dal.entities.User;
+import edu.kmaooad.capstone23.users.events.UserCreated;
+import edu.kmaooad.capstone23.users.handlers.CreateUserHandler;
+import edu.kmaooad.capstone23.users.mocks.UserMocks;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
-import org.junit.jupiter.api.BeforeEach;
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -17,32 +26,69 @@ public class CreateParticipantHandlerTest extends HandlerTest<Participant, Creat
   @Inject
   CreateChatHandler createChatHandler;
 
-  @BeforeEach
-  public void initCommand() {
-    command = new CreateParticipant();
+  @Inject
+  CreateUserHandler createUserHandler;
+
+  private String chatId;
+
+  private String userId;
+
+  @Test
+  @DisplayName("Should succeed if command is valid")
+  public void shouldSucceedIfValidCommand() {
+    seedChat();
+    seedUser();
+
+    Result<ParticipantCreated> result = run(
+        ParticipantMocks.makeParticipant(new ObjectId(chatId), new ObjectId(userId))
+    );
+
+    assertHandled(result);
   }
 
-  /*
-    @Test
-    @DisplayName("Should succeed if command is valid")
-    // TODO: requires user creation flow, coming in next PRs
-  */
+  private void seedChat() {
+    Chat chat = ChatMocks.validChat();
+
+    CreateChat createChatCommand = new CreateChat();
+
+    createChatCommand.setName(chat.name);
+    createChatCommand.setAccessType(chat.accessType);
+
+    Result<ChatCreated> result = createChatHandler.handle(createChatCommand);
+
+    chatId = result.getValue().getId();
+  }
+
+  private void seedUser() {
+    User user = UserMocks.validUser();
+
+    CreateUser createUserCommand = new CreateUser();
+
+    createUserCommand.setFirstName(user.firstName);
+    createUserCommand.setLastName(user.lastName);
+    createUserCommand.setEmail(user.email);
+
+    Result<UserCreated> result = createUserHandler.handle(createUserCommand);
+
+    userId = result.getValue().getId();
+  }
 
   @Test
   @DisplayName("Should succeed if command is valid")
   public void shouldDenyCommandIfNoChatOrUser() {
-    Result<ParticipantCreated> result = handleCommandWithPayload(
-        ParticipantMocks.invalidParticipant()
-    );
+    Result<ParticipantCreated> result = run(ParticipantMocks.invalidParticipant());
 
     assertDenied(result);
   }
 
   @Override
-  protected Result<ParticipantCreated> handleCommandWithPayload(Participant participant) {
+  public void initCommand() {
+    command = new CreateParticipant();
+  }
+
+  @Override
+  protected void insertPayload(Participant participant) {
     command.setChatId(participant.chatId.toHexString());
     command.setUserId(participant.userId.toHexString());
-
-    return handler.handle(command);
   }
 }

--- a/app/src/test/java/edu/kmaooad/capstone23/communication/mocks/ChatMocks.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/communication/mocks/ChatMocks.java
@@ -1,8 +1,9 @@
 package edu.kmaooad.capstone23.communication.mocks;
 
+import edu.kmaooad.capstone23.common.Mocks;
 import edu.kmaooad.capstone23.communication.dal.entities.Chat;
 
-public class ChatMocks {
+public class ChatMocks extends Mocks {
   public static Chat validChat() {
     Chat chat = new Chat();
 
@@ -23,7 +24,7 @@ public class ChatMocks {
   public static Chat chatWithExhaustiveName() {
     Chat chat = new Chat();
 
-    chat.name = "Lorem".repeat(50);
+    chat.name = mockLongString();
     chat.accessType = Chat.AccessType.Public;
 
     return chat;

--- a/app/src/test/java/edu/kmaooad/capstone23/users/controllers/CreateUserControllerTest.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/users/controllers/CreateUserControllerTest.java
@@ -1,0 +1,64 @@
+package edu.kmaooad.capstone23.users.controllers;
+
+import edu.kmaooad.capstone23.common.ControllerTest;
+import edu.kmaooad.capstone23.users.dal.entities.User;
+import edu.kmaooad.capstone23.users.mocks.UserMocks;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class CreateUserControllerTest extends ControllerTest<User> {
+  CreateUserControllerTest() {
+    super("/users/create");
+  }
+
+  @Test
+  @DisplayName("Should succeed if all fields valid")
+  public void shouldSucceedIfPayloadValid() {
+    assertRequestSucceeds(
+        UserMocks.validUser()
+    );
+  }
+
+  @Test
+  @DisplayName("Should deny request if first name is invalid")
+  public void shouldDenyRequestIfInvalidFirstName() {
+    assertRequestFails(
+        UserMocks.userWithNoFirstName()
+    );
+  }
+
+  @Test
+  @DisplayName("Should deny request if first name is exhaustive")
+  public void shouldDenyRequestIfExhaustiveFirstName() {
+    assertRequestFails(
+        UserMocks.userWithExhaustiveFirstName()
+    );
+  }
+
+
+  @Test
+  @DisplayName("Should deny request if last name is invalid")
+  public void shouldDenyRequestIfInvalidLastName() {
+    assertRequestFails(
+        UserMocks.userWithNoLastName()
+    );
+  }
+
+  @Test
+  @DisplayName("Should deny request if last name is exhaustive")
+  public void shouldDenyRequestIfExhaustiveLastName() {
+    assertRequestFails(
+        UserMocks.userWithExhaustiveFirstName()
+    );
+  }
+
+  @Test
+  @DisplayName("Should deny request if email is invalid")
+  public void shouldDenyRequestIfInvalidEmail() {
+    assertRequestFails(
+        UserMocks.userWithInvalidEmail()
+    );
+  }
+}

--- a/app/src/test/java/edu/kmaooad/capstone23/users/handlers/CreateUserHandlerTest.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/users/handlers/CreateUserHandlerTest.java
@@ -1,0 +1,76 @@
+package edu.kmaooad.capstone23.users.handlers;
+
+import edu.kmaooad.capstone23.common.HandlerTest;
+import edu.kmaooad.capstone23.common.Result;
+import edu.kmaooad.capstone23.users.commands.CreateUser;
+import edu.kmaooad.capstone23.users.dal.entities.User;
+import edu.kmaooad.capstone23.users.events.UserCreated;
+import edu.kmaooad.capstone23.users.mocks.UserMocks;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class CreateUserHandlerTest extends HandlerTest<User, CreateUser, UserCreated> {
+  @Test
+  @DisplayName("Should succeed if all fields valid")
+  public void shouldSucceedIfPayloadValid() {
+    Result<UserCreated> result = run(UserMocks.validUser());
+
+    assertHandled(result);
+  }
+
+  @Test
+  @DisplayName("Should deny request if first name is invalid")
+  public void shouldDenyRequestIfInvalidFirstName() {
+    Result<UserCreated> result = run(UserMocks.userWithNoFirstName());
+
+    assertDenied(result);
+  }
+
+  @Test
+  @DisplayName("Should deny request if first name is exhaustive")
+  public void shouldDenyRequestIfExhaustiveFirstName() {
+    Result<UserCreated> result = run(UserMocks.userWithExhaustiveFirstName());
+
+    assertDenied(result);
+  }
+
+
+  @Test
+  @DisplayName("Should deny request if last name is invalid")
+  public void shouldDenyRequestIfInvalidLastName() {
+    Result<UserCreated> result = run(UserMocks.userWithNoLastName()
+    );
+
+    assertDenied(result);
+  }
+
+  @Test
+  @DisplayName("Should deny request if last name is exhaustive")
+  public void shouldDenyRequestIfExhaustiveLastName() {
+    Result<UserCreated> result = run(UserMocks.userWithExhaustiveLastName());
+
+    assertDenied(result);
+  }
+
+  @Test
+  @DisplayName("Should deny request if email is invalid")
+  public void shouldDenyRequestIfInvalidEmail() {
+    Result<UserCreated> result = run(UserMocks.userWithInvalidEmail());
+
+    assertDenied(result);
+  }
+
+  @Override
+  protected void initCommand() {
+    command = new CreateUser();
+  }
+
+  @Override
+  protected void insertPayload(User user) {
+    command.setFirstName(user.firstName);
+    command.setLastName(user.lastName);
+    command.setEmail(user.email);
+  }
+}

--- a/app/src/test/java/edu/kmaooad/capstone23/users/mocks/UserMocks.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/users/mocks/UserMocks.java
@@ -1,14 +1,55 @@
 package edu.kmaooad.capstone23.users.mocks;
 
+import edu.kmaooad.capstone23.common.Mocks;
 import edu.kmaooad.capstone23.users.dal.entities.User;
 
-public class UserMocks {
+public class UserMocks extends Mocks {
   public static User validUser() {
     User user = new User();
 
     user.firstName = "John";
     user.lastName = "Doe";
-    user.email = "john.doe@mail.com";
+    user.email = mockValidEmail();
+
+    return user;
+  }
+
+  public static User userWithNoFirstName() {
+    User user = UserMocks.validUser();
+
+    user.firstName = "";
+
+    return user;
+  }
+
+  public static User userWithExhaustiveFirstName() {
+    User user = UserMocks.validUser();
+
+    user.firstName = mockLongString();
+
+    return user;
+  }
+
+  public static User userWithNoLastName() {
+    User user = UserMocks.validUser();
+
+    user.lastName = "";
+
+    return user;
+  }
+
+  public static User userWithExhaustiveLastName() {
+    User user = UserMocks.validUser();
+
+    user.lastName = mockLongString();
+
+    return user;
+  }
+
+  public static User userWithInvalidEmail() {
+    User user = UserMocks.validUser();
+
+    user.email = mockInvalidEmail();
 
     return user;
   }


### PR DESCRIPTION
## Summary

In this PR:
- improve `HandlerTest` allowing to automatically initialize command and insert entity as payload to handler
- add more mocks
- add user creation flow
- add tests themselves

### Test results (+ finalized `CreateParticipantHandlerTest` as mentioned [here](https://github.com/kmaooad/capstone23/pull/161))
![Screenshot 2023-10-01 at 17 36 32](https://github.com/kmaooad/capstone23/assets/75496546/12fe4f24-d18d-457d-a98f-6bfce863a27e)
![Screenshot 2023-10-01 at 17 36 04](https://github.com/kmaooad/capstone23/assets/75496546/a90dcc4e-7acc-4e65-9bc3-3d6f93666b85)
![image](https://github.com/kmaooad/capstone23/assets/75496546/db1edf21-8912-4c8d-8e1d-936a24a413d0)