### PR TITLE
Feature/user email uniqueness

### DIFF
--- a/app/src/main/java/edu/kmaooad/capstone23/experts/commands/AssignExpertToProject.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/experts/commands/AssignExpertToProject.java
@@ -1,9 +1,12 @@
 package edu.kmaooad.capstone23.experts.commands;
 
+import jakarta.validation.constraints.NotNull;
 import org.bson.types.ObjectId;
 
 public class AssignExpertToProject {
+    @NotNull
     private ObjectId expertId;
+    @NotNull
     private ObjectId projectId;
 
     public ObjectId getProjectId() {

--- a/app/src/main/java/edu/kmaooad/capstone23/lifecycle/ApplicationLifecycleObserver.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/lifecycle/ApplicationLifecycleObserver.java
@@ -18,10 +18,10 @@ public class ApplicationLifecycleObserver {
 
     void onStart(@Observes StartupEvent ev) {
         // Ensure uniqueness of User email
+        usersRepository.mongoCollection().dropIndexes();
         Document indexMember = new Document("email", 1);
         IndexOptions options = new IndexOptions().unique(true);
         membersRepository.mongoCollection().createIndex(indexMember, options);
-        usersRepository.mongoCollection().dropIndexes();
         Document indexUser = new Document("unique_email", 1);
         options.sparse(true);
         usersRepository.mongoCollection().createIndex(indexUser, options);

--- a/app/src/main/java/edu/kmaooad/capstone23/lifecycle/ApplicationLifecycleObserver.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/lifecycle/ApplicationLifecycleObserver.java
@@ -21,9 +21,8 @@ public class ApplicationLifecycleObserver {
         Document indexMember = new Document("email", 1);
         IndexOptions options = new IndexOptions().unique(true);
         membersRepository.mongoCollection().createIndex(indexMember, options);
-        // delete previously duplicated test data
-        usersRepository.delete("email", "john.doe@mail.com");
-        Document indexUser = new Document("email", 2);
+        Document indexUser = new Document("unique_email", 1);
+        options.sparse(true);
         usersRepository.mongoCollection().createIndex(indexUser, options);
     }
 }

--- a/app/src/main/java/edu/kmaooad/capstone23/lifecycle/ApplicationLifecycleObserver.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/lifecycle/ApplicationLifecycleObserver.java
@@ -2,6 +2,7 @@ package edu.kmaooad.capstone23.lifecycle;
 
 import com.mongodb.client.model.IndexOptions;
 import edu.kmaooad.capstone23.members.dal.MembersRepository;
+import edu.kmaooad.capstone23.users.dal.repositories.UserRepository;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
@@ -12,11 +13,15 @@ import org.bson.Document;
 public class ApplicationLifecycleObserver {
     @Inject
     MembersRepository membersRepository;
+    @Inject
+    UserRepository usersRepository;
 
     void onStart(@Observes StartupEvent ev) {
-        // Ensure uniqueness of Member email
-        Document index = new Document("email", 1);
+        // Ensure uniqueness of User email
+        Document indexMember = new Document("email", 1);
         IndexOptions options = new IndexOptions().unique(true);
-        membersRepository.mongoCollection().createIndex(index, options);
+        membersRepository.mongoCollection().createIndex(indexMember, options);
+        Document indexUser = new Document("email", 2);
+        usersRepository.mongoCollection().createIndex(indexUser, options);
     }
 }

--- a/app/src/main/java/edu/kmaooad/capstone23/lifecycle/ApplicationLifecycleObserver.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/lifecycle/ApplicationLifecycleObserver.java
@@ -18,7 +18,6 @@ public class ApplicationLifecycleObserver {
 
     void onStart(@Observes StartupEvent ev) {
         // Ensure uniqueness of User email
-        usersRepository.mongoCollection().dropIndexes();
         Document indexMember = new Document("email", 1);
         IndexOptions options = new IndexOptions().unique(true);
         membersRepository.mongoCollection().createIndex(indexMember, options);

--- a/app/src/main/java/edu/kmaooad/capstone23/lifecycle/ApplicationLifecycleObserver.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/lifecycle/ApplicationLifecycleObserver.java
@@ -21,6 +21,7 @@ public class ApplicationLifecycleObserver {
         Document indexMember = new Document("email", 1);
         IndexOptions options = new IndexOptions().unique(true);
         membersRepository.mongoCollection().createIndex(indexMember, options);
+        usersRepository.mongoCollection().dropIndexes();
         Document indexUser = new Document("unique_email", 1);
         options.sparse(true);
         usersRepository.mongoCollection().createIndex(indexUser, options);

--- a/app/src/main/java/edu/kmaooad/capstone23/lifecycle/ApplicationLifecycleObserver.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/lifecycle/ApplicationLifecycleObserver.java
@@ -21,6 +21,8 @@ public class ApplicationLifecycleObserver {
         Document indexMember = new Document("email", 1);
         IndexOptions options = new IndexOptions().unique(true);
         membersRepository.mongoCollection().createIndex(indexMember, options);
+        // delete previously duplicated test data
+        usersRepository.delete("email", "john.doe@mail.com");
         Document indexUser = new Document("email", 2);
         usersRepository.mongoCollection().createIndex(indexUser, options);
     }

--- a/app/src/main/java/edu/kmaooad/capstone23/users/dal/entities/User.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/users/dal/entities/User.java
@@ -1,12 +1,14 @@
 package edu.kmaooad.capstone23.users.dal.entities;
 
 import io.quarkus.mongodb.panache.common.MongoEntity;
+import org.bson.codecs.pojo.annotations.BsonProperty;
 import org.bson.types.ObjectId;
 
 @MongoEntity(collection = "users")
 public class User {
-  public ObjectId id;
-  public String firstName;
-  public String lastName;
-  public String email;
+    public ObjectId id;
+    public String firstName;
+    public String lastName;
+    @BsonProperty("unique_email")
+    public String email;
 }

--- a/app/src/main/java/edu/kmaooad/capstone23/users/dal/repositories/UserRepository.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/users/dal/repositories/UserRepository.java
@@ -18,7 +18,7 @@ public class UserRepository implements PanacheMongoRepository<User> {
   }
 
   public Optional<User> findByEmail(@Email String email) {
-    PanacheQuery<User> user = find("email", email);
+    PanacheQuery<User> user = find("unique_email", email);
 
     return user.firstResultOptional();
   }

--- a/app/src/test/java/edu/kmaooad/capstone23/common/Mocks.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/common/Mocks.java
@@ -2,6 +2,8 @@ package edu.kmaooad.capstone23.common;
 
 import org.bson.types.ObjectId;
 
+import java.util.UUID;
+
 public class Mocks {
   public static ObjectId mockObjectId() {
     return new ObjectId();
@@ -16,6 +18,6 @@ public class Mocks {
   }
 
   public static String mockValidEmail() {
-    return "john.doe@mail.com";
+    return UUID.randomUUID().toString().concat("@mail.com");
   }
 }

--- a/app/src/test/java/edu/kmaooad/capstone23/experts/handlers/AssignExpertToProjectHandlerTest.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/experts/handlers/AssignExpertToProjectHandlerTest.java
@@ -4,15 +4,12 @@ import edu.kmaooad.capstone23.common.CommandHandler;
 import edu.kmaooad.capstone23.common.ErrorCode;
 import edu.kmaooad.capstone23.common.Result;
 import edu.kmaooad.capstone23.competences.commands.CreateProj;
-import edu.kmaooad.capstone23.competences.dal.Project;
 import edu.kmaooad.capstone23.competences.dal.ProjsRepository;
 import edu.kmaooad.capstone23.competences.events.ProjCreated;
-import edu.kmaooad.capstone23.departments.dal.DepartmentsRepository;
 import edu.kmaooad.capstone23.experts.commands.AssignExpertToProject;
 import edu.kmaooad.capstone23.experts.commands.CreateExpert;
 import edu.kmaooad.capstone23.experts.dal.Expert;
 import edu.kmaooad.capstone23.experts.dal.ExpertsRepository;
-import edu.kmaooad.capstone23.experts.events.ExpertAssigned;
 import edu.kmaooad.capstone23.experts.events.ExpertAssignedToProject;
 import edu.kmaooad.capstone23.experts.events.ExpertCreated;
 import edu.kmaooad.capstone23.orgs.commands.CreateOrg;
@@ -48,7 +45,7 @@ public class AssignExpertToProjectHandlerTest {
     CommandHandler<AssignExpertToProject, ExpertAssignedToProject> assignedExpertToProjectCommandHandler;
     @Inject
     CommandHandler<CreateExpert, ExpertCreated> expertCreatedCommandHandler;
-  
+
     @BeforeEach
     public void setUp() {
         org = createTestOrg();
@@ -60,8 +57,8 @@ public class AssignExpertToProjectHandlerTest {
         AssignExpertToProject assignExpertToProject = new AssignExpertToProject();
         assignExpertToProject.setExpertId(createTestExpertWithProj());
         assignExpertToProject.setProjectId(project);
-      
-         Result<ExpertAssignedToProject> result = assignedExpertToProjectCommandHandler.handle(assignExpertToProject);
+
+        Result<ExpertAssignedToProject> result = assignedExpertToProjectCommandHandler.handle(assignExpertToProject);
 
         Assertions.assertFalse(result.isSuccess());
         Assertions.assertNull(result.getValue());
@@ -80,7 +77,7 @@ public class AssignExpertToProjectHandlerTest {
         Assertions.assertNotNull(result.getValue());
         Assertions.assertFalse(result.getValue().getMemberId().isEmpty());
     }
-  
+
     @Test
     public void testEmptyExpert() {
         AssignExpertToProject assignExpertToProject = new AssignExpertToProject();
@@ -90,18 +87,18 @@ public class AssignExpertToProjectHandlerTest {
 
         Assertions.assertFalse(result.isSuccess());
         Assertions.assertNull(result.getValue());
-        Assertions.assertEquals(result.getErrorCode(), ErrorCode.CONFLICT);
+        Assertions.assertEquals(ErrorCode.VALIDATION_FAILED, result.getErrorCode());
     }
-  
+
     @Test
     public void testEmptyProject() {
-       AssignExpertToProject assignExpertToProject = new AssignExpertToProject();
-       assignExpertToProject.setExpertId(createTestExpert());
+        AssignExpertToProject assignExpertToProject = new AssignExpertToProject();
+        assignExpertToProject.setExpertId(createTestExpert());
 
-       Result<ExpertAssignedToProject> result = assignedExpertToProjectCommandHandler.handle(assignExpertToProject);
+        Result<ExpertAssignedToProject> result = assignedExpertToProjectCommandHandler.handle(assignExpertToProject);
 
-       Assertions.assertFalse(result.isSuccess());
-       Assertions.assertNull(result.getValue());
+        Assertions.assertFalse(result.isSuccess());
+        Assertions.assertNull(result.getValue());
     }
 
     private Org createTestOrg() {

--- a/app/src/test/java/edu/kmaooad/capstone23/users/repo/UserRepositoryTest.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/users/repo/UserRepositoryTest.java
@@ -1,0 +1,47 @@
+package edu.kmaooad.capstone23.users.repo;
+
+import com.mongodb.MongoException;
+import edu.kmaooad.capstone23.users.dal.entities.User;
+import edu.kmaooad.capstone23.users.dal.repositories.UserRepository;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@QuarkusTest
+public class UserRepositoryTest {
+    @Inject
+    UserRepository userRepository;
+
+    String email;
+
+    @BeforeEach
+    void setUp() {
+        var user = new User();
+        user.lastName = "last";
+        user.firstName = "first";
+        user.email = (UUID.randomUUID()).toString().concat("@email.com");
+        email = user.email;
+        userRepository.persist(user);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        userRepository.findByEmail(email).ifPresent(value -> userRepository.deleteById(value.id));
+    }
+
+    @Test
+    public void testInsertDuplicateEmailWithGeneratedMethodThrowsMongoException() {
+        var user = new User();
+        user.lastName = "last";
+        user.firstName = "first";
+        user.email = email;
+
+        assertThrows(MongoException.class, () -> userRepository.persist(user));
+    }
+}


### PR DESCRIPTION
This pull request introduces a new field "unique_email" to users collection and creates a sparse unique index for it with the idea being that this field should henceforth be used as THE "email" field for the User entity and all of the logic connected to it.