### PR TITLE
remove direct OrgRepository dependency

### DIFF
--- a/app/src/main/java/edu/kmaooad/capstone23/common/ErrorCode.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/common/ErrorCode.java
@@ -3,7 +3,7 @@ package edu.kmaooad.capstone23.common;
 public enum ErrorCode {
     VALIDATION_FAILED,
     EXCEPTION,
-    ENTITY_NOT_FOUN,
+    ENTITY_NOT_FOUND,
     NOT_FOUND,
     CONFLICT
 }

--- a/app/src/main/java/edu/kmaooad/capstone23/members/handlers/CreateMemberByCorpEmailHandler.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/members/handlers/CreateMemberByCorpEmailHandler.java
@@ -6,9 +6,9 @@ import edu.kmaooad.capstone23.common.Result;
 import edu.kmaooad.capstone23.members.commands.CreateBasicMember;
 import edu.kmaooad.capstone23.members.commands.CreateMemberByCorpEmail;
 import edu.kmaooad.capstone23.members.events.BasicMemberCreated;
+import edu.kmaooad.capstone23.members.services.OrgService;
 import edu.kmaooad.capstone23.members.utils.CorpEmailParser;
 import edu.kmaooad.capstone23.orgs.dal.Org;
-import edu.kmaooad.capstone23.orgs.dal.OrgsRepository;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 
@@ -18,16 +18,15 @@ import java.util.Optional;
 public class CreateMemberByCorpEmailHandler implements CommandHandler<CreateMemberByCorpEmail, BasicMemberCreated> {
     @Inject
     CommandHandler<CreateBasicMember, BasicMemberCreated> handler;
-
     @Inject
-    OrgsRepository orgsRepository;
+    OrgService orgService;
     @Inject
     CorpEmailParser corpEmailParser;
 
     @Override
     public Result<BasicMemberCreated> handle(CreateMemberByCorpEmail command) {
         String orgEmailDomain = corpEmailParser.getCorpEmailDomain(command.getCorpEmail());
-        Optional<Org> memberOrg = orgsRepository.findByEmailDomainOptional(orgEmailDomain);
+        Optional<Org> memberOrg = orgService.findByEmailDomainOptional(orgEmailDomain);
         if (memberOrg.isEmpty())
             return new Result<>(ErrorCode.VALIDATION_FAILED, "Organisation not found");
 

--- a/app/src/main/java/edu/kmaooad/capstone23/members/services/OrgService.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/members/services/OrgService.java
@@ -1,0 +1,9 @@
+package edu.kmaooad.capstone23.members.services;
+
+import edu.kmaooad.capstone23.orgs.dal.Org;
+
+import java.util.Optional;
+
+public interface OrgService {
+    Optional<Org> findByEmailDomainOptional(String emailDomain);
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/members/services/impl/OrgServiceInternalInterdependentImpl.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/members/services/impl/OrgServiceInternalInterdependentImpl.java
@@ -1,0 +1,20 @@
+package edu.kmaooad.capstone23.members.services.impl;
+
+import edu.kmaooad.capstone23.members.services.OrgService;
+import edu.kmaooad.capstone23.orgs.dal.Org;
+import edu.kmaooad.capstone23.orgs.dal.OrgsRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Optional;
+
+@ApplicationScoped
+public class OrgServiceInternalInterdependentImpl implements OrgService {
+    @Inject
+    OrgsRepository orgsRepository;
+
+    @Override
+    public Optional<Org> findByEmailDomainOptional(String emailDomain) {
+        return orgsRepository.findByEmailDomainOptional(emailDomain);
+    }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/orgs/handlers/EditHiringStatusHandler.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/orgs/handlers/EditHiringStatusHandler.java
@@ -4,10 +4,7 @@ import edu.kmaooad.capstone23.common.CommandHandler;
 import edu.kmaooad.capstone23.common.ErrorCode;
 import edu.kmaooad.capstone23.common.Result;
 import edu.kmaooad.capstone23.orgs.commands.SetHiringStatus;
-import edu.kmaooad.capstone23.orgs.dal.Job;
-import edu.kmaooad.capstone23.orgs.dal.JobsRepository;
-import edu.kmaooad.capstone23.orgs.dal.Org;
-import edu.kmaooad.capstone23.orgs.dal.OrgsRepository;
+import edu.kmaooad.capstone23.orgs.dal.*;
 import edu.kmaooad.capstone23.orgs.events.HiringStatusChanged;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -32,7 +29,7 @@ public class EditHiringStatusHandler implements CommandHandler<SetHiringStatus, 
             return new Result<>(ErrorCode.ENTITY_NOT_FOUND, "Organization not found");
         }
 
-        org.hiringStatus = command.getHiringStatus();
+        org.hiringStatus = String.valueOf(command.getHiringStatus());
         orgsRepository.update(org);
 
         List<Job> jobs = jobsRepository.findByOrgId(command.getOrgId());
@@ -43,7 +40,7 @@ public class EditHiringStatusHandler implements CommandHandler<SetHiringStatus, 
         }
 
         HiringStatusChanged result = new HiringStatusChanged(
-                org.hiringStatus,
+                HiringStatus.valueOf(org.hiringStatus),
                 org.id.toString()
         );
 

--- a/app/src/test/java/edu/kmaooad/capstone23/activities/controllers/RemoveSkillFromActivityControllerTest.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/activities/controllers/RemoveSkillFromActivityControllerTest.java
@@ -22,8 +22,6 @@ public class RemoveSkillFromActivityControllerTest {
 
     @Inject
     private ExtracurricularActivityRepository activityRepository;
-    @Inject
-    private ExtracurricularActivity activity;
 
     private ObjectId activityId;
     private ObjectId skillId;


### PR DESCRIPTION
Introduces OrgService into members module, for simplicity adds an implementation that depends on OrgsRepository, the idea being that we can provide another implementation (e. g. through an http client) as needed, decoupling our handler logic from OrgsRepository. Removes the OrgsRepository dependency from CreateMemberByCorpEmailHandler, that being the presumed UoW for this PR.