### PR TITLE
Add notifications for events

### DIFF
--- a/app/src/main/java/edu/kmaooad/capstone23/competences/events/SkillDeleted.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/competences/events/SkillDeleted.java
@@ -1,14 +1,17 @@
 package edu.kmaooad.capstone23.competences.events;
 
 import edu.kmaooad.capstone23.competences.dal.Skill;
+import edu.kmaooad.capstone23.notifications.Notify;
+import edu.kmaooad.capstone23.notifications.impls.EmailNotificationChannel;
 
 import java.util.Optional;
 
+@Notify(EmailNotificationChannel.class)
 public class SkillDeleted {
     private Skill skill;
 
     public SkillDeleted(Optional<Skill> skill) {
-        this.skill = skill;
+        this.skill = skill.get();
     }
 
     public Skill getSkill() {

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/NotificationChannel.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/NotificationChannel.java
@@ -1,0 +1,5 @@
+package edu.kmaooad.capstone23.notifications;
+
+public interface NotificationChannel {
+    void sendNotification(String message);
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/NotificationSendingHandler.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/NotificationSendingHandler.java
@@ -1,0 +1,42 @@
+package edu.kmaooad.capstone23.notifications;
+
+import edu.kmaooad.capstone23.common.CommandHandler;
+import edu.kmaooad.capstone23.common.Result;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+@Decorator
+public class NotificationSendingHandler<T1, T2> implements CommandHandler<T1, T2> {
+
+    @Inject
+    @Delegate
+    private CommandHandler<T1, T2> decoratee;
+
+    @Inject
+    Instance<NotificationChannel> logStrategies;
+
+    @Override
+    public Result<T2> handle(T1 command) {
+        Result<T2> result = decoratee.handle(command);
+        if (result.isSuccess()) {
+            NotificationChannel notificationChannel = getNotificationChannel((Class<T2>) result.getValue().getClass());
+            if (notificationChannel != null) {
+                notificationChannel.sendNotification("Command " + command.getClass().getSimpleName() + " executed successfully");
+            }
+        }
+        return result;
+    }
+
+    private NotificationChannel getNotificationChannel(Class<T2> commandClass) {
+        var annotation = commandClass.getAnnotation(Notify.class);
+        if (annotation == null) {
+            return null;
+        }
+
+        Class<? extends NotificationChannel> notificationChannelClass = annotation.value();
+
+        return logStrategies.select(notificationChannelClass).get();
+    }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/Notify.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/Notify.java
@@ -1,0 +1,12 @@
+package edu.kmaooad.capstone23.notifications;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Notify {
+    Class<? extends NotificationChannel> value();
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/impls/EmailNotificationChannel.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/impls/EmailNotificationChannel.java
@@ -1,0 +1,12 @@
+package edu.kmaooad.capstone23.notifications.impls;
+
+import edu.kmaooad.capstone23.notifications.NotificationChannel;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class EmailNotificationChannel implements NotificationChannel {
+    @Override
+    public void sendNotification(String message) {
+        System.out.println("Sending telegram notification: " + message + " ...");
+    }    
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/impls/TelegramNotificationChannel.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/impls/TelegramNotificationChannel.java
@@ -1,0 +1,12 @@
+package edu.kmaooad.capstone23.notifications.impls;
+
+import edu.kmaooad.capstone23.notifications.NotificationChannel;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class TelegramNotificationChannel implements NotificationChannel {
+    @Override
+    public void sendNotification(String message) {
+        System.out.println("Sending telegram notification: " + message + " ...");
+    }    
+}


### PR DESCRIPTION
In this pr I added `NotificationChannel` interface and two classes which implement it: `EmailNotificationChannel` and `TelegramNotificationChannel`. 

I also added `@Notify` annotation, which you can use for `Event` classes like so: `@Notify(EmailNotificationChannel.class)`. This way you specify the events (target for annotation) and the way you want to receive notifications (tg/email). 

I also added `NotificationSendingHandler` decorator which wraps `CommandHandler` and if the event has `@Notify` annotation, it is sent using the specified method.

See `SkillDeleted` class for example usage.
