### PR TITLE
Final test: Add notification service

### DIFF
--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/commands/CreateNotificationSetting.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/commands/CreateNotificationSetting.java
@@ -1,0 +1,28 @@
+package edu.kmaooad.capstone23.notifications.commands;
+
+import jakarta.validation.constraints.NotNull;
+
+public class CreateNotificationSetting {
+
+//    @NotNull
+//    private String userId;
+
+    @NotNull
+    private String notificationType;
+
+    @NotNull
+    private String notificationEvent;
+
+    public CreateNotificationSetting(String notificationType, String notificationEvent) {
+        this.notificationType = notificationType;
+        this.notificationEvent = notificationEvent;
+    }
+
+    public String getNotificationType() {
+        return notificationType;
+    }
+
+    public String getNotificationEvent() {
+        return notificationEvent;
+    }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/controllers/CreateNotificationSettingController.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/controllers/CreateNotificationSettingController.java
@@ -1,0 +1,18 @@
+package edu.kmaooad.capstone23.notifications.controllers;
+
+import edu.kmaooad.capstone23.common.TypicalController;
+import edu.kmaooad.capstone23.notifications.commands.CreateNotificationSetting;
+import edu.kmaooad.capstone23.notifications.events.NotificationSettingCreated;
+import jakarta.ws.rs.Path;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+
+@Path("/notifications/create")
+@APIResponse(responseCode = "200", content = {
+        @Content(mediaType = "application/json",
+                schema = @Schema(implementation = NotificationSettingCreated.class))
+})
+public class CreateNotificationSettingController
+        extends TypicalController<CreateNotificationSetting, NotificationSettingCreated > {
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/dal/Notification.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/dal/Notification.java
@@ -1,0 +1,15 @@
+package edu.kmaooad.capstone23.notifications.dal;
+
+public class Notification {
+
+    private String message;
+
+
+    public Notification(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/dal/NotificationEvent.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/dal/NotificationEvent.java
@@ -1,0 +1,6 @@
+package edu.kmaooad.capstone23.notifications.dal;
+
+public enum NotificationEvent {
+    CV_DELETED,
+    CV_CREATED,
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/dal/NotificationSetting.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/dal/NotificationSetting.java
@@ -1,0 +1,24 @@
+package edu.kmaooad.capstone23.notifications.dal;
+
+import io.quarkus.mongodb.panache.common.MongoEntity;
+import org.bson.types.ObjectId;
+
+@MongoEntity(collection = "notification-setting")
+public class NotificationSetting {
+
+    public ObjectId id;
+    // notifications should be specific to users
+    // public User user;
+    public NotificationType notificationType;
+    public NotificationEvent notificationEvent;
+
+    public NotificationSetting() {
+
+    }
+
+    public NotificationSetting(NotificationType notificationType,
+                               NotificationEvent notificationEvent) {
+        this.notificationType = notificationType;
+        this.notificationEvent = notificationEvent;
+    }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/dal/NotificationSettingRepository.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/dal/NotificationSettingRepository.java
@@ -1,0 +1,8 @@
+package edu.kmaooad.capstone23.notifications.dal;
+
+import io.quarkus.mongodb.panache.PanacheMongoRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class NotificationSettingRepository implements PanacheMongoRepository<NotificationSetting> {
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/dal/NotificationType.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/dal/NotificationType.java
@@ -1,0 +1,7 @@
+package edu.kmaooad.capstone23.notifications.dal;
+
+public enum NotificationType {
+    EMAIL,
+    SMS,
+    TELEGRAM,
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/events/NotificationSettingCreated.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/events/NotificationSettingCreated.java
@@ -1,0 +1,18 @@
+package edu.kmaooad.capstone23.notifications.events;
+
+public class NotificationSettingCreated {
+
+    private String id;
+
+    public NotificationSettingCreated(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/handler_decorators/NotifyingCreateCVHandler.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/handler_decorators/NotifyingCreateCVHandler.java
@@ -1,0 +1,58 @@
+package edu.kmaooad.capstone23.notifications.handler_decorators;
+
+import edu.kmaooad.capstone23.common.CommandHandler;
+import edu.kmaooad.capstone23.common.Result;
+import edu.kmaooad.capstone23.cvs.commands.CreateCV;
+import edu.kmaooad.capstone23.cvs.events.CVCreated;
+import edu.kmaooad.capstone23.notifications.dal.Notification;
+import edu.kmaooad.capstone23.notifications.dal.NotificationEvent;
+import edu.kmaooad.capstone23.notifications.dal.NotificationSetting;
+import edu.kmaooad.capstone23.notifications.dal.NotificationType;
+import edu.kmaooad.capstone23.notifications.observers.EmailNotificationObserver;
+import edu.kmaooad.capstone23.notifications.observers.SmsNotificationObserver;
+import edu.kmaooad.capstone23.notifications.observers.TelegramNotificationObserver;
+import edu.kmaooad.capstone23.notifications.services.NotificationService;
+import edu.kmaooad.capstone23.notifications.services.NotificationSettingService;
+import edu.kmaooad.capstone23.notifications.utils.Notifying;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Default;
+import jakarta.inject.Inject;
+
+import java.util.List;
+
+@RequestScoped
+@Notifying
+public class NotifyingCreateCVHandler implements CommandHandler<CreateCV, CVCreated> {
+
+    @Inject
+    @Default
+    CommandHandler<CreateCV, CVCreated> handler;
+
+    @Inject
+    NotificationSettingService settingService;
+
+    @Inject
+    NotificationService service;
+
+    @Override
+    public Result<CVCreated> handle(CreateCV command) {
+        Result<CVCreated> result = handler.handle(command);
+        if (!result.isSuccess())
+            return result;
+
+        List<NotificationSetting> settings = settingService.list("notificationEvent", NotificationEvent.CV_CREATED);
+
+        for (NotificationSetting setting : settings) {
+            NotificationType type = setting.notificationType;
+            switch (type) {
+                case EMAIL -> service.addObserver(new EmailNotificationObserver());
+                case SMS -> service.addObserver(new SmsNotificationObserver());
+                case TELEGRAM -> service.addObserver(new TelegramNotificationObserver());
+            }
+        }
+
+
+        service.notify(new Notification("CV successfully created"));
+        return result;
+    }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/handlers/CreateNotificationSettingHandler.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/handlers/CreateNotificationSettingHandler.java
@@ -1,0 +1,45 @@
+package edu.kmaooad.capstone23.notifications.handlers;
+
+import edu.kmaooad.capstone23.common.CommandHandler;
+import edu.kmaooad.capstone23.common.ErrorCode;
+import edu.kmaooad.capstone23.common.Result;
+import edu.kmaooad.capstone23.notifications.commands.CreateNotificationSetting;
+import edu.kmaooad.capstone23.notifications.dal.NotificationEvent;
+import edu.kmaooad.capstone23.notifications.dal.NotificationSetting;
+import edu.kmaooad.capstone23.notifications.dal.NotificationType;
+import edu.kmaooad.capstone23.notifications.events.NotificationSettingCreated;
+import edu.kmaooad.capstone23.notifications.services.NotificationSettingService;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+
+@RequestScoped
+public class CreateNotificationSettingHandler
+        implements CommandHandler<CreateNotificationSetting, NotificationSettingCreated> {
+
+    @Inject
+    NotificationSettingService service;
+
+    @Override
+    public Result<NotificationSettingCreated> handle(CreateNotificationSetting createCommand) {
+        NotificationEvent event;
+        NotificationType type;
+
+        try {
+            event = NotificationEvent.valueOf(createCommand.getNotificationEvent());
+        } catch (IllegalArgumentException e) {
+            return new Result<>(ErrorCode.NOT_FOUND, "event " + createCommand.getNotificationEvent() + " doesn't exist");
+        }
+
+        try {
+            type = NotificationType.valueOf(createCommand.getNotificationType());
+        } catch (IllegalArgumentException e) {
+            return new Result<>(ErrorCode.NOT_FOUND, "type " + createCommand.getNotificationType() + " doesn't exist");
+        }
+
+        NotificationSetting setting = new NotificationSetting(type, event);
+        service.persist(setting);
+
+        NotificationSettingCreated result = new NotificationSettingCreated(setting.id.toString());
+        return new Result<>(result);
+    }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/observers/EmailNotificationObserver.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/observers/EmailNotificationObserver.java
@@ -1,0 +1,12 @@
+package edu.kmaooad.capstone23.notifications.observers;
+
+import edu.kmaooad.capstone23.notifications.dal.Notification;
+
+public class EmailNotificationObserver implements NotificationObserver{
+
+    @Override
+    public void notify(Notification notification) {
+        System.out.print(" EMAIL: " + notification.getMessage());
+    }
+
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/observers/NotificationObserver.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/observers/NotificationObserver.java
@@ -1,0 +1,9 @@
+package edu.kmaooad.capstone23.notifications.observers;
+
+import edu.kmaooad.capstone23.notifications.dal.Notification;
+
+public interface NotificationObserver {
+
+    void notify(Notification notification);
+
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/observers/SmsNotificationObserver.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/observers/SmsNotificationObserver.java
@@ -1,0 +1,11 @@
+package edu.kmaooad.capstone23.notifications.observers;
+
+import edu.kmaooad.capstone23.notifications.dal.Notification;
+
+public class SmsNotificationObserver implements NotificationObserver {
+
+    @Override
+    public void notify(Notification notification) {
+        System.out.print(" SMS: " + notification.getMessage());
+    }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/observers/TelegramNotificationObserver.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/observers/TelegramNotificationObserver.java
@@ -1,0 +1,11 @@
+package edu.kmaooad.capstone23.notifications.observers;
+
+import edu.kmaooad.capstone23.notifications.dal.Notification;
+
+public class TelegramNotificationObserver implements NotificationObserver{
+
+    @Override
+    public void notify(Notification notification) {
+        System.out.print(" TELEGRAM: " + notification.getMessage());
+    }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/services/NotificationService.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/services/NotificationService.java
@@ -1,0 +1,30 @@
+package edu.kmaooad.capstone23.notifications.services;
+
+import edu.kmaooad.capstone23.notifications.dal.Notification;
+import edu.kmaooad.capstone23.notifications.observers.NotificationObserver;
+import jakarta.enterprise.context.RequestScoped;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequestScoped
+public class NotificationService {
+
+    private List<NotificationObserver> observers;
+
+    public NotificationService(){
+        observers = new ArrayList<>();
+    }
+
+    public void addObserver(NotificationObserver observer) {
+        observers.add(observer);
+    }
+
+    public void removeObserver(NotificationObserver observer) {
+        observers.remove(observer);
+    }
+
+    public void notify(Notification notification) {
+        observers.forEach(o -> o.notify(notification));
+    }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/services/NotificationSettingService.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/services/NotificationSettingService.java
@@ -1,0 +1,25 @@
+package edu.kmaooad.capstone23.notifications.services;
+
+import edu.kmaooad.capstone23.notifications.dal.NotificationEvent;
+import edu.kmaooad.capstone23.notifications.dal.NotificationSetting;
+import edu.kmaooad.capstone23.notifications.dal.NotificationSettingRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.List;
+
+@ApplicationScoped
+public class NotificationSettingService {
+
+    @Inject
+    NotificationSettingRepository repository;
+
+
+    public void persist(NotificationSetting setting) {
+        repository.persist(setting);
+    }
+
+    public List<NotificationSetting> list(String notificationEvent, NotificationEvent cvCreated) {
+       return repository.list(notificationEvent, cvCreated);
+    }
+}

--- a/app/src/main/java/edu/kmaooad/capstone23/notifications/utils/Notifying.java
+++ b/app/src/main/java/edu/kmaooad/capstone23/notifications/utils/Notifying.java
@@ -1,0 +1,20 @@
+package edu.kmaooad.capstone23.notifications.utils;
+
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/*
+ * Used to resolve conflict between NotifyingCreateCVHandler
+ * and CreateCVHandler (both implement CommandHandler<CreateCV, CVCreated>)
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, FIELD})
+public @interface Notifying {
+}

--- a/app/src/test/java/edu/kmaooad/capstone23/notifications/controllers/CreateNotificationSettingControllerTests.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/notifications/controllers/CreateNotificationSettingControllerTests.java
@@ -1,0 +1,44 @@
+package edu.kmaooad.capstone23.notifications.controllers;
+
+import edu.kmaooad.capstone23.notifications.dal.NotificationSettingRepository;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+public class CreateNotificationSettingControllerTests {
+
+    @Inject
+    NotificationSettingRepository repository;
+
+    @BeforeEach
+    void setup(){
+        repository.deleteAll();
+    }
+
+    @AfterEach
+    void clear(){
+        repository.deleteAll();
+    }
+
+    @Test
+    public void createValidNotificationSetting(){
+        Map<String, Object> notificationSetting = new HashMap<>();
+        notificationSetting.put("notificationType", "EMAIL");
+        notificationSetting.put("notificationEvent", "CV_CREATED");
+
+        given().contentType("application/json")
+                .body(notificationSetting)
+                .when()
+                .post("/notifications/create")
+                .then()
+                .statusCode(200);
+    }
+}

--- a/app/src/test/java/edu/kmaooad/capstone23/notifications/services/NotificationServiceTests.java
+++ b/app/src/test/java/edu/kmaooad/capstone23/notifications/services/NotificationServiceTests.java
@@ -1,0 +1,70 @@
+package edu.kmaooad.capstone23.notifications.services;
+
+import edu.kmaooad.capstone23.common.CommandHandler;
+import edu.kmaooad.capstone23.cvs.commands.CreateCV;
+import edu.kmaooad.capstone23.cvs.dal.CV;
+import edu.kmaooad.capstone23.cvs.events.CVCreated;
+import edu.kmaooad.capstone23.notifications.dal.NotificationEvent;
+import edu.kmaooad.capstone23.notifications.dal.NotificationSetting;
+import edu.kmaooad.capstone23.notifications.dal.NotificationSettingRepository;
+import edu.kmaooad.capstone23.notifications.dal.NotificationType;
+import edu.kmaooad.capstone23.notifications.utils.Notifying;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+public class NotificationServiceTests {
+
+    @Inject
+    @Notifying
+    CommandHandler<CreateCV, CVCreated> createCVHandler;
+    ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+
+    @Inject
+    NotificationSettingRepository settingRepository;
+
+    @BeforeEach
+    public void setUp() {
+        System.setOut(new PrintStream(outputStreamCaptor));
+        settingRepository.deleteAll();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        System.setOut(System.out);
+        settingRepository.deleteAll();
+    }
+
+    @Test
+    void createCV_GetNotificationOnEmailAndTelegram() {
+        NotificationSetting emailSetting = new NotificationSetting(NotificationType.EMAIL, NotificationEvent.CV_CREATED);
+        NotificationSetting telegramSetting = new NotificationSetting(NotificationType.TELEGRAM, NotificationEvent.CV_CREATED);
+        settingRepository.persist(emailSetting);
+        settingRepository.persist(telegramSetting);
+
+        CreateCV createCV = provideCVToCreate();
+        createCVHandler.handle(createCV);
+
+        assertEquals("EMAIL: CV successfully created TELEGRAM: CV successfully created",
+                outputStreamCaptor.toString().trim());
+    }
+
+    private CreateCV provideCVToCreate() {
+        CreateCV createCV = new CreateCV();
+        createCV.setDateTimeCreated(LocalDateTime.now());
+        createCV.setTextInfo("some simple info 11111");
+        createCV.setStatus(CV.Status.OPEN);
+        createCV.setVisibility(CV.Visibility.VISIBLE);
+        return createCV;
+    }
+
+}


### PR DESCRIPTION
Final test: part 1 & part 2.
NotificationSetting is used to set event types and notification methods.
Handller classes from handler_decorators package are used to send notification when a corresponding event happens.
